### PR TITLE
fix: polish the controls a chat UI leans on

### DIFF
--- a/src/qml/Logos/Controls/LogosButton.qml
+++ b/src/qml/Logos/Controls/LogosButton.qml
@@ -4,66 +4,64 @@ import QtQuick.Layouts
 
 import Logos.Theme
 import Logos.Controls
-// LogosButton — a themed push button with an optional icon.
+// LogosButton — a themed push button with optional icons.
 //
 // A Control that pairs a centered text label with an optional LogosIcon on
-// the left or right. The implicit size follows the content, so a button left
+// either side of it. The implicit size follows the content, so a button left
 // at its natural size fits its own label; a label constrained by an explicit
 // width is elided rather than overflowing the button. Colors, border and
 // cursor react to hover/press and enabled state.
 //
 // Public API:
-//     text     button label. Drives the implicit width. Elided with "…" when
-//              the button is narrower than the label.
-//     icon     IconSpec grouping the icon's source/size/position/color/
-//              brightness (see below). Empty source renders no icon.
-//     variant  LogosButton.Variant.Primary or .Secondary (default). Drives
-//              the background and border palette.
-//     radius   background corner radius. Default = Theme.spacing.radiusXlarge.
-//     clicked  signal emitted when an enabled button is clicked.
+//     text         button label. Drives the implicit width. Elided with "…"
+//                  when the button is narrower than the label.
+//     font         label typography. Defaults to the 12px medium step; set
+//                  font.pixelSize for a button that carries another step.
+//     leadingIcon  IconSpec for the icon before the label (see below).
+//     trailingIcon IconSpec for the icon after the label. Both may be set.
+//     variant      LogosButton.Variant.Primary or .Secondary (default). Drives
+//                  the background and border palette.
+//     radius       background corner radius. Default = Theme.spacing.radiusXlarge.
+//     clicked      signal emitted when an enabled button is clicked.
 //
-// icon (IconSpec) fields:
+// IconSpec fields:
 //     source     URL of the icon asset. Empty renders nothing.
 //     size       icon footprint in px. Default 20.
-//     position   LogosButton.IconPosition.Left (default) or .Right.
 //     color      tint applied to the icon. Default = Theme.palette.text.
 //                Falls back to textMuted when the button is disabled.
 //     brightness MultiEffect brightness before tinting. Default 0.
 //
 // Read-only inspection aliases (for tests):
-//     mouseAreaItem  the MouseArea handling clicks/hover
-//     backgroundItem the background Rectangle
-//     labelItem      the text label
-//     iconItem       the active LogosIcon (left or right per icon.position)
+//     mouseAreaItem     the MouseArea handling clicks/hover
+//     backgroundItem    the background Rectangle
+//     labelItem         the text label
+//     leadingIconItem   the LogosIcon before the label
+//     trailingIconItem  the LogosIcon after the label
 //
 // Example:
 //     LogosButton {
 //         text: "Refresh"
 //         variant: LogosButton.Variant.Primary
-//         icon.source: LogosIcons.refresh
-//         icon.position: LogosButton.IconPosition.Left
+//         leadingIcon.source: LogosIcons.refresh
 //         onClicked: model.refresh()
 //     }
 Control {
     id: root
 
     enum Variant { Primary, Secondary }
-    enum IconPosition { Left, Right }
 
     component IconSpec: QtObject {
         property url source: ""
         property int size: 20
-        property int position: LogosButton.IconPosition.Left
         property real brightness: 0
         property color color: Theme.palette.text
 
         readonly property bool isVisible: source.toString().length > 0
-        readonly property bool isLeft: position === LogosButton.IconPosition.Left
-        readonly property bool isRight: position === LogosButton.IconPosition.Right
     }
 
     property alias text: label.text
-    readonly property IconSpec icon: IconSpec {}
+    readonly property IconSpec leadingIcon: IconSpec {}
+    readonly property IconSpec trailingIcon: IconSpec {}
     property real radius: Theme.spacing.radiusXlarge
     property int variant: LogosButton.Variant.Secondary
 
@@ -75,9 +73,8 @@ Control {
     readonly property alias mouseAreaItem: mouseArea
     readonly property alias backgroundItem: bg
     readonly property alias labelItem: label
-    readonly property alias iconLeftItem: iconLeft
-    readonly property alias iconRightItem: iconRight
-    readonly property Item iconItem: root.icon.isRight ? iconRight : iconLeft
+    readonly property alias leadingIconItem: iconLeft
+    readonly property alias trailingIconItem: iconRight
 
     // Floors keep short labels ("OK") on a balanced pill, and hold the height
     // steady whether or not the button carries a default-sized (20px) icon;
@@ -89,6 +86,9 @@ Control {
     topPadding: Theme.spacing.medium
     bottomPadding: Theme.spacing.medium
     hoverEnabled: true
+    font.family: Theme.typography.publicSans
+    font.pixelSize: Theme.typography.secondaryText
+    font.weight: Theme.typography.weightMedium
 
     background: Rectangle {
         id: bg
@@ -115,21 +115,20 @@ Control {
 
         LogosIcon {
             id: iconLeft
-            source: root.icon.isLeft ? root.icon.source : ""
-            color: root.enabled ? root.icon.color : Theme.palette.textMuted
-            visible: root.icon.isVisible && root.icon.isLeft
-            Layout.preferredWidth: root.icon.size
-            Layout.preferredHeight: root.icon.size
+            source: root.leadingIcon.source
+            color: root.enabled ? root.leadingIcon.color : Theme.palette.textMuted
+            visible: root.leadingIcon.isVisible
+            Layout.preferredWidth: root.leadingIcon.size
+            Layout.preferredHeight: root.leadingIcon.size
             Layout.alignment: Qt.AlignVCenter
-            brightness: root.icon.brightness
+            brightness: root.leadingIcon.brightness
         }
 
         LogosText {
             id: label
             Layout.fillWidth: true
             color: root.enabled ? Theme.palette.text : Theme.palette.textMuted
-            font.pixelSize: Theme.typography.secondaryText
-            font.weight: Theme.typography.weightMedium
+            font: root.font
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             Layout.alignment: Qt.AlignVCenter
@@ -138,13 +137,13 @@ Control {
 
         LogosIcon {
             id: iconRight
-            source: root.icon.isRight ? root.icon.source : ""
-            color: root.enabled ? root.icon.color : Theme.palette.textMuted
-            visible: root.icon.isVisible && root.icon.isRight
-            Layout.preferredWidth: root.icon.size
-            Layout.preferredHeight: root.icon.size
+            source: root.trailingIcon.source
+            color: root.enabled ? root.trailingIcon.color : Theme.palette.textMuted
+            visible: root.trailingIcon.isVisible
+            Layout.preferredWidth: root.trailingIcon.size
+            Layout.preferredHeight: root.trailingIcon.size
             Layout.alignment: Qt.AlignVCenter
-            brightness: root.icon.brightness
+            brightness: root.trailingIcon.brightness
         }
     }
 

--- a/src/qml/Logos/Controls/LogosButton.qml
+++ b/src/qml/Logos/Controls/LogosButton.qml
@@ -7,11 +7,14 @@ import Logos.Controls
 // LogosButton — a themed push button with an optional icon.
 //
 // A Control that pairs a centered text label with an optional LogosIcon on
-// the left or right. Long labels are elided rather than overflowing the
-// button. Colors, border and cursor react to hover/press and enabled state.
+// the left or right. The implicit size follows the content, so a button left
+// at its natural size fits its own label; a label constrained by an explicit
+// width is elided rather than overflowing the button. Colors, border and
+// cursor react to hover/press and enabled state.
 //
 // Public API:
-//     text     button label. Elided with "…" when it overflows.
+//     text     button label. Drives the implicit width. Elided with "…" when
+//              the button is narrower than the label.
 //     icon     IconSpec grouping the icon's source/size/position/color/
 //              brightness (see below). Empty source renders no icon.
 //     variant  LogosButton.Variant.Primary or .Secondary (default). Drives
@@ -76,10 +79,15 @@ Control {
     readonly property alias iconRightItem: iconRight
     readonly property Item iconItem: root.icon.isRight ? iconRight : iconLeft
 
-    implicitWidth: 200
-    implicitHeight: 50
+    // Floors keep short labels ("OK") on a balanced pill, and hold the height
+    // steady whether or not the button carries a default-sized (20px) icon;
+    // beyond them the content decides.
+    implicitWidth: Math.max(100, implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(44, implicitContentHeight + topPadding + bottomPadding)
     leftPadding: Theme.spacing.large
     rightPadding: Theme.spacing.large
+    topPadding: Theme.spacing.medium
+    bottomPadding: Theme.spacing.medium
     hoverEnabled: true
 
     background: Rectangle {
@@ -109,8 +117,7 @@ Control {
             id: iconLeft
             source: root.icon.isLeft ? root.icon.source : ""
             color: root.enabled ? root.icon.color : Theme.palette.textMuted
-            visible: root.icon.isVisible
-            opacity: root.icon.isLeft ? 1 : 0
+            visible: root.icon.isVisible && root.icon.isLeft
             Layout.preferredWidth: root.icon.size
             Layout.preferredHeight: root.icon.size
             Layout.alignment: Qt.AlignVCenter
@@ -133,8 +140,7 @@ Control {
             id: iconRight
             source: root.icon.isRight ? root.icon.source : ""
             color: root.enabled ? root.icon.color : Theme.palette.textMuted
-            visible: root.icon.isVisible
-            opacity: root.icon.isRight ? 1 : 0
+            visible: root.icon.isVisible && root.icon.isRight
             Layout.preferredWidth: root.icon.size
             Layout.preferredHeight: root.icon.size
             Layout.alignment: Qt.AlignVCenter

--- a/src/qml/Logos/Controls/LogosDialog.qml
+++ b/src/qml/Logos/Controls/LogosDialog.qml
@@ -24,6 +24,13 @@ Dialog {
     modal: true
     padding: Theme.spacing.large
 
+    Overlay.modal: Rectangle {
+        objectName: "modalScrim"
+        color: Theme.palette.scrim
+
+        Behavior on opacity { NumberAnimation { duration: 120 } }
+    }
+
     background: Rectangle {
         id: bg
         color: root.backgroundColor

--- a/src/qml/Logos/Controls/LogosScrollBar.qml
+++ b/src/qml/Logos/Controls/LogosScrollBar.qml
@@ -3,6 +3,10 @@ import QtQuick.Controls
 
 import Logos.Theme
 
+// An overlay scroll bar: hidden while the content sits idle, revealed only when
+// there is something to scroll and the user is engaging with it (dragging it,
+// hovering it, or just after a scroll step), then it fades back out. Set
+// policy: ScrollBar.AlwaysOn to keep it pinned instead.
 ScrollBar {
     id: root
 
@@ -13,12 +17,34 @@ ScrollBar {
     // Exposed for inspection (e.g., from tests). Read-only.
     readonly property alias barItem: bar
 
+    hoverEnabled: true
+
+    QtObject {
+        id: d
+
+        // Keeps the bar up for a moment after a scroll, so a wheel step or
+        // flick is visible before it fades. Restarted on every position change.
+        readonly property Timer activityTimer: Timer {
+            interval: 800
+        }
+    }
+    onPositionChanged: d.activityTimer.restart()
+
     contentItem: Rectangle {
         id: bar
         implicitWidth: root.barThickness
         implicitHeight: root.barThickness
         radius: root.barThickness / 2
         color: root.pressed || root.hovered ? root.barColorActive : root.barColor
+
+        // Show only for real overflow, and only while the user is engaging with
+        // it. Reveal is not tied to ScrollBar.active, which the runtime can latch
+        // on and never clear, leaving the bar stuck visible.
+        opacity: root.policy === ScrollBar.AlwaysOn
+                 || (root.size < 1.0 && (root.pressed || root.hovered || d.activityTimer.running))
+                 ? 1 : 0
+
+        Behavior on opacity { NumberAnimation { duration: 200 } }
         Behavior on color { ColorAnimation { duration: 120 } }
     }
 

--- a/src/qml/Logos/Controls/LogosTextField.qml
+++ b/src/qml/Logos/Controls/LogosTextField.qml
@@ -28,6 +28,12 @@ Control {
     rightPadding: 12
     clip: true
 
+    focusPolicy: Qt.StrongFocus
+    // Focus handed to the field (forceActiveFocus, tab, key navigation) lands on
+    // the wrapper control; the editor is where it must end up.
+    onActiveFocusChanged: if (activeFocus)
+        input.forceActiveFocus()
+
     background: Rectangle {
         id: bg
         radius: Theme.spacing.radiusSmall

--- a/src/qml/Logos/Theme/ColorPalette.qml
+++ b/src/qml/Logos/Theme/ColorPalette.qml
@@ -12,6 +12,7 @@ QtObject {
     readonly property color whiteOpacity63: getColor(white, 0.63)
     readonly property color black: "#000000"
     readonly property color blackOpacity10: getColor(black, 0.1)
+    readonly property color blackOpacity50: getColor(black, 0.5)
     
     // Grey shades
     readonly property color gray50: "#FAFAFA"

--- a/src/qml/Logos/Theme/DarkTheme.qml
+++ b/src/qml/Logos/Theme/DarkTheme.qml
@@ -68,4 +68,5 @@ QtObject {
     readonly property color overlayDark: Qt.rgba(colors.gray875.r, colors.gray875.g, colors.gray875.b, 0.3)
     readonly property color overlayLight: colors.whiteOpacity06
     readonly property color overlayOrange: colors.orange400Opacity30
+    readonly property color scrim: colors.blackOpacity50
 }

--- a/src/qml/Logos/Theme/Typography.qml
+++ b/src/qml/Logos/Theme/Typography.qml
@@ -17,6 +17,11 @@ QtObject {
     // Fallback to system font if custom font fails
     readonly property string publicSans: publicSansRegular.status == FontLoader.Ready ? publicSansRegular.name : "sans-serif"
 
+    // Family for hex identifiers, addresses and code, where fixed-width glyphs
+    // aid scanning and copying. No monospace face is bundled, so this resolves
+    // to the platform's own.
+    readonly property string mono: "monospace"
+
     // weights
     readonly property int weightRegular: 400
     readonly property int weightMedium: 500

--- a/storybook/pages/ColorsPage.qml
+++ b/storybook/pages/ColorsPage.qml
@@ -144,7 +144,8 @@ Rectangle {
                     { name: "glassStrong",   value: Theme.palette.glassStrong },
                     { name: "overlayDark",   value: Theme.palette.overlayDark },
                     { name: "overlayLight",  value: Theme.palette.overlayLight },
-                    { name: "overlayOrange", value: Theme.palette.overlayOrange }
+                    { name: "overlayOrange", value: Theme.palette.overlayOrange },
+                    { name: "scrim",         value: Theme.palette.scrim }
                 ]
             }
 

--- a/storybook/pages/LogosButtonPage.qml
+++ b/storybook/pages/LogosButtonPage.qml
@@ -54,13 +54,9 @@ Rectangle {
 
                 LogosButton {
                     text: "Default"
-                    implicitWidth: 160
-                    implicitHeight: 50
                 }
                 LogosButton {
                     text: "Disabled"
-                    implicitWidth: 160
-                    implicitHeight: 50
                     enabled: false
                 }
             }
@@ -86,21 +82,15 @@ Rectangle {
 
                 LogosButton {
                     text: "Neutral"
-                    implicitWidth: 160
-                    implicitHeight: 50
                 }
                 LogosButton {
                     text: "Primary"
                     variant: LogosButton.Variant.Primary
-                    implicitWidth: 160
-                    implicitHeight: 50
                 }
                 LogosButton {
                     text: "Back"
                     icon.source: LogosIcons.arrowLeft
                     icon.position: LogosButton.IconPosition.Left
-                    implicitWidth: 160
-                    implicitHeight: 50
                 }
                 LogosButton {
                     text: "Next"
@@ -108,13 +98,11 @@ Rectangle {
                     icon.source: LogosIcons.arrowRight
                     icon.position: LogosButton.IconPosition.Right
                     icon.brightness: 1
-                    implicitWidth: 160
-                    implicitHeight: 50
                 }
+                // Constrained on purpose: the one case where the label elides.
                 LogosButton {
                     text: "This is a very long label that will not fit inside the button width"
-                    implicitWidth: 160
-                    implicitHeight: 50
+                    Layout.preferredWidth: 160
                 }
             }
         }
@@ -142,8 +130,6 @@ Rectangle {
                     id: liveButton
                     text: textInput.text || "Live button"
                     enabled: !disableSwitch.checked
-                    implicitWidth: 200
-                    implicitHeight: 50
                     onClicked: clickCount.value++
                 }
 

--- a/storybook/pages/LogosButtonPage.qml
+++ b/storybook/pages/LogosButtonPage.qml
@@ -89,15 +89,18 @@ Rectangle {
                 }
                 LogosButton {
                     text: "Back"
-                    icon.source: LogosIcons.arrowLeft
-                    icon.position: LogosButton.IconPosition.Left
+                    leadingIcon.source: LogosIcons.arrowLeft
                 }
                 LogosButton {
                     text: "Next"
                     variant: LogosButton.Variant.Primary
-                    icon.source: LogosIcons.arrowRight
-                    icon.position: LogosButton.IconPosition.Right
-                    icon.brightness: 1
+                    trailingIcon.source: LogosIcons.arrowRight
+                    trailingIcon.brightness: 1
+                }
+                LogosButton {
+                    text: "Both"
+                    leadingIcon.source: LogosIcons.arrowLeft
+                    trailingIcon.source: LogosIcons.arrowRight
                 }
                 // Constrained on purpose: the one case where the label elides.
                 LogosButton {

--- a/tests/tst_LogosButton.qml
+++ b/tests/tst_LogosButton.qml
@@ -17,6 +17,20 @@ TestCase {
         anchors.centerIn: parent
     }
 
+    // Sizing pair: same label, one with an icon. Declared rather than toggled
+    // at runtime because the layout only re-reads an item's visibility when
+    // the scene itself is shown, which it is not under the test runner.
+    LogosButton {
+        id: plainSizing
+        text: "A label long enough to clear the minimum width"
+    }
+
+    LogosButton {
+        id: iconSizing
+        text: plainSizing.text
+        icon.source: "qrc:/test-icon.png"
+    }
+
     SignalSpy {
         id: clickedSpy
         target: btn
@@ -26,6 +40,8 @@ TestCase {
     function init() {
         clickedSpy.clear()
         btn.enabled = true
+        btn.width = undefined
+        btn.height = undefined
         btn.text = "Click me"
         btn.variant = LogosButton.Variant.Secondary
         btn.icon.source = ""
@@ -88,16 +104,16 @@ TestCase {
         btn.icon.source = "qrc:/test-icon.png"
         btn.icon.position = LogosButton.IconPosition.Left
         compare(btn.iconItem, btn.iconLeftItem)
-        compare(btn.iconLeftItem.opacity, 1)
-        compare(btn.iconRightItem.opacity, 0)
+        compare(btn.iconLeftItem.source.toString(), "qrc:/test-icon.png")
+        compare(btn.iconRightItem.source.toString(), "")
     }
 
     function test_icon_shows_on_right() {
         btn.icon.source = "qrc:/test-icon.png"
         btn.icon.position = LogosButton.IconPosition.Right
         compare(btn.iconItem, btn.iconRightItem)
-        compare(btn.iconRightItem.opacity, 1)
-        compare(btn.iconLeftItem.opacity, 0)
+        compare(btn.iconRightItem.source.toString(), "qrc:/test-icon.png")
+        compare(btn.iconLeftItem.source.toString(), "")
     }
 
     function test_icon_tint_follows_icon_color() {
@@ -107,8 +123,43 @@ TestCase {
     }
 
     function test_long_text_is_elided() {
+        btn.width = 120
         btn.text = "This is a very long label that will not fit inside the button width"
-        tryCompare(btn.labelItem, "truncated", true)
-        verify(btn.labelItem.width <= btn.width)
+        // The label is only laid out on the next polish, so poll rather than
+        // read the width straight after the assignment.
+        tryVerify(function() { return btn.labelItem.width <= btn.width })
+        compare(btn.labelItem.truncated, true)
+    }
+
+    function test_default_width_fits_the_label() {
+        btn.text = "This is a very long label that will not fit inside 100px"
+        tryVerify(function() { return !btn.labelItem.truncated })
+        verify(btn.width >= btn.labelItem.implicitWidth + btn.leftPadding + btn.rightPadding)
+    }
+
+    function test_short_label_keeps_the_minimum_width() {
+        btn.text = "OK"
+        tryCompare(btn, "implicitWidth", 100)
+    }
+
+    function test_icon_adds_a_single_slot_to_the_width() {
+        tryVerify(function() { return !iconSizing.labelItem.truncated })
+        compare(iconSizing.implicitWidth,
+                plainSizing.implicitWidth + iconSizing.icon.size + iconSizing.contentItem.spacing)
+    }
+
+    function test_height_clears_the_label() {
+        verify(btn.implicitHeight >= btn.labelItem.implicitHeight + btn.topPadding + btn.bottomPadding)
+    }
+
+    function test_height_is_the_same_with_and_without_an_icon() {
+        compare(iconSizing.implicitHeight, plainSizing.implicitHeight)
+    }
+
+    function test_explicit_size_wins() {
+        btn.width = 300
+        btn.height = 60
+        tryCompare(btn, "width", 300)
+        tryCompare(btn, "height", 60)
     }
 }

--- a/tests/tst_LogosButton.qml
+++ b/tests/tst_LogosButton.qml
@@ -28,7 +28,14 @@ TestCase {
     LogosButton {
         id: iconSizing
         text: plainSizing.text
-        icon.source: "qrc:/test-icon.png"
+        leadingIcon.source: "qrc:/test-icon.png"
+    }
+
+    LogosButton {
+        id: bothIconsSizing
+        text: plainSizing.text
+        leadingIcon.source: "qrc:/test-icon.png"
+        trailingIcon.source: "qrc:/test-icon.png"
     }
 
     SignalSpy {
@@ -44,9 +51,11 @@ TestCase {
         btn.height = undefined
         btn.text = "Click me"
         btn.variant = LogosButton.Variant.Secondary
-        btn.icon.source = ""
-        btn.icon.position = LogosButton.IconPosition.Left
-        btn.icon.color = Theme.palette.text
+        btn.leadingIcon.source = ""
+        btn.leadingIcon.color = Theme.palette.text
+        btn.trailingIcon.source = ""
+        btn.trailingIcon.color = Theme.palette.text
+        btn.font.pixelSize = Theme.typography.secondaryText
     }
 
     function test_renders_text() {
@@ -82,44 +91,44 @@ TestCase {
 
     function test_disabled_wins_over_primary() {
         btn.variant = LogosButton.Variant.Primary
-        btn.icon.source = "qrc:/test-icon.png"
+        btn.leadingIcon.source = "qrc:/test-icon.png"
         btn.enabled = false
         tryCompare(btn.backgroundItem, "color", Theme.palette.backgroundMuted)
         compare(btn.labelItem.color, Theme.palette.textMuted)
-        compare(btn.iconItem.color, Theme.palette.textMuted)
+        compare(btn.leadingIconItem.color, Theme.palette.textMuted)
     }
 
     function test_icon_source_is_empty_after_init() {
-        compare(btn.icon.source.toString(), "")
+        compare(btn.leadingIcon.source.toString(), "")
+        compare(btn.trailingIcon.source.toString(), "")
     }
 
     function test_icon_source_round_trips() {
-        btn.icon.source = "qrc:/test-icon.png"
-        compare(btn.icon.source.toString(), "qrc:/test-icon.png")
-        btn.icon.source = ""
-        compare(btn.icon.source.toString(), "")
+        btn.leadingIcon.source = "qrc:/test-icon.png"
+        compare(btn.leadingIcon.source.toString(), "qrc:/test-icon.png")
+        btn.leadingIcon.source = ""
+        compare(btn.leadingIcon.source.toString(), "")
     }
 
-    function test_icon_shows_on_left() {
-        btn.icon.source = "qrc:/test-icon.png"
-        btn.icon.position = LogosButton.IconPosition.Left
-        compare(btn.iconItem, btn.iconLeftItem)
-        compare(btn.iconLeftItem.source.toString(), "qrc:/test-icon.png")
-        compare(btn.iconRightItem.source.toString(), "")
-    }
-
-    function test_icon_shows_on_right() {
-        btn.icon.source = "qrc:/test-icon.png"
-        btn.icon.position = LogosButton.IconPosition.Right
-        compare(btn.iconItem, btn.iconRightItem)
-        compare(btn.iconRightItem.source.toString(), "qrc:/test-icon.png")
-        compare(btn.iconLeftItem.source.toString(), "")
+    function test_leading_and_trailing_icons_are_independent() {
+        btn.leadingIcon.source = "qrc:/test-icon.png"
+        compare(btn.leadingIconItem.source.toString(), "qrc:/test-icon.png")
+        compare(btn.trailingIconItem.source.toString(), "")
+        btn.trailingIcon.source = "qrc:/other-icon.png"
+        compare(btn.leadingIconItem.source.toString(), "qrc:/test-icon.png")
+        compare(btn.trailingIconItem.source.toString(), "qrc:/other-icon.png")
     }
 
     function test_icon_tint_follows_icon_color() {
-        btn.icon.source = "qrc:/test-icon.png"
-        btn.icon.color = Theme.palette.primary
-        compare(btn.iconItem.color, Theme.palette.primary)
+        btn.leadingIcon.source = "qrc:/test-icon.png"
+        btn.leadingIcon.color = Theme.palette.primary
+        compare(btn.leadingIconItem.color, Theme.palette.primary)
+    }
+
+    function test_label_font_follows_the_button_font() {
+        compare(btn.labelItem.font.pixelSize, Theme.typography.secondaryText)
+        btn.font.pixelSize = Theme.typography.primaryText
+        compare(btn.labelItem.font.pixelSize, Theme.typography.primaryText)
     }
 
     function test_long_text_is_elided() {
@@ -145,7 +154,13 @@ TestCase {
     function test_icon_adds_a_single_slot_to_the_width() {
         tryVerify(function() { return !iconSizing.labelItem.truncated })
         compare(iconSizing.implicitWidth,
-                plainSizing.implicitWidth + iconSizing.icon.size + iconSizing.contentItem.spacing)
+                plainSizing.implicitWidth + iconSizing.leadingIcon.size + iconSizing.contentItem.spacing)
+    }
+
+    function test_both_icons_add_two_slots_to_the_width() {
+        tryVerify(function() { return !bothIconsSizing.labelItem.truncated })
+        compare(bothIconsSizing.implicitWidth,
+                iconSizing.implicitWidth + bothIconsSizing.trailingIcon.size + bothIconsSizing.contentItem.spacing)
     }
 
     function test_height_clears_the_label() {

--- a/tests/tst_LogosDialog.qml
+++ b/tests/tst_LogosDialog.qml
@@ -1,7 +1,9 @@
 import QtQuick
+import QtQuick.Controls
 import QtTest
 
 import Logos.Controls
+import Logos.Theme
 
 TestCase {
     name: "LogosDialog"
@@ -52,6 +54,18 @@ TestCase {
     function test_footer_visible_when_actions_set() {
         dlg.open()
         tryCompare(dlg.footerItem, "visible", true)
+        dlg.close()
+    }
+
+    function test_modal_scrim_dims_the_background() {
+        dlg.open()
+        tryCompare(dlg, "opened", true)
+        // The overlay owns the scrim instance, so no dialog alias can reach it;
+        // it is found by name instead.
+        var dim = findChild(dlg.Overlay.overlay, "modalScrim")
+        verify(dim)
+        compare(dim.color, Theme.palette.scrim)
+        tryCompare(dim, "opacity", 1)
         dlg.close()
     }
 

--- a/tests/tst_LogosScrollBar.qml
+++ b/tests/tst_LogosScrollBar.qml
@@ -18,10 +18,20 @@ TestCase {
         ScrollBar.vertical: LogosScrollBar { id: bar }
     }
 
+    Flickable {
+        id: fittingScroll
+        anchors.fill: parent
+        contentWidth: width
+        contentHeight: height
+        ScrollBar.vertical: LogosScrollBar { id: fittingBar }
+    }
+
     function init() {
         // QtTest runs alphabetically; reset state so leakage from earlier
         // tests doesn't break later ones.
         bar.barThickness = 6
+        bar.policy = ScrollBar.AsNeeded
+        bar.position = 0
     }
 
     function test_default_thickness() { compare(bar.barThickness, 6) }
@@ -33,5 +43,28 @@ TestCase {
     function test_bar_thickness_setter() {
         bar.barThickness = 10
         tryCompare(bar.barItem, "implicitWidth", 10)
+    }
+
+    function test_hidden_when_content_fits() {
+        compare(fittingBar.size, 1)
+        tryCompare(fittingBar.barItem, "opacity", 0)
+    }
+
+    // The overlay bar stays hidden at rest even when the content overflows: it
+    // is not tied to ScrollBar.active, which the runtime can leave stuck on.
+    function test_hidden_at_rest_when_content_overflows() {
+        verify(bar.size < 1)
+        tryCompare(bar.barItem, "opacity", 0)
+    }
+
+    function test_shown_after_a_scroll() {
+        verify(bar.size < 1)
+        bar.position = 0.3
+        tryCompare(bar.barItem, "opacity", 1)
+    }
+
+    function test_always_on_shows_without_activity() {
+        bar.policy = ScrollBar.AlwaysOn
+        tryCompare(bar.barItem, "opacity", 1)
     }
 }

--- a/tests/tst_LogosTextField.qml
+++ b/tests/tst_LogosTextField.qml
@@ -30,6 +30,9 @@ TestCase {
         field.echoMode = TextInput.Normal
         field.validator = null
         field.readOnly = false
+        // QtTest runs alphabetically; take focus back so a focus test does not
+        // leak a focused border into later ones.
+        root.forceActiveFocus()
     }
 
     function test_text_alias_get_set() {
@@ -85,5 +88,10 @@ TestCase {
     function test_read_only_propagates_to_text_input() {
         field.readOnly = true
         compare(field.textInput.readOnly, true)
+    }
+
+    function test_focus_reaches_the_editor() {
+        field.forceActiveFocus()
+        tryCompare(field.textInput, "activeFocus", true)
     }
 }


### PR DESCRIPTION
### fix: hide the scroll bar unless the content is being scrolled

An idle scroll area kept its bar drawn, which reads as clutter and, on content that only just overflows, as a permanent handle with nothing to move. Tying the reveal to ScrollBar.active did not solve it: the runtime can latch active on and never clear it, so the bar stayed stuck visible.

Show the bar only for real overflow and only while the user engages with it (dragging it, hovering it, or briefly after a scroll step), then fade it out.

### fix: size LogosButton from its label

The implicit size was pinned at 200x50 whatever the button contained, so a label wider than the 168px left inside the horizontal padding was elided by the control's own default, and every caller had to hardcode a width per label to get its text to show.

Derive the implicit size from the content the way Control is meant to: the width from the label plus the horizontal padding, the height from the tallest item in the row plus the vertical padding, both floored (100x44) so a short label still sits on a balanced pill and the height stays the same with or without an icon. The idle icon is hidden instead of held at zero opacity, so it stops reserving a slot in a width that now follows the content. An explicitly set width or height still wins, and constrained labels still elide. LogosIconButton keeps its fixed sizing: it is a square icon chip whose size is its documented knob, with no text that could be cut off.

### feat: dim the background behind a modal dialog

LogosDialog is modal but nothing dimmed behind it, so a dialog sits on the same dark surface as the content it blocks and reads as one more panel on the page rather than as something demanding an answer.

Paint the modal overlay with a new scrim token (50% black), fading with the same 120ms the other controls animate in. The existing overlayDark token could not serve: it is a 30% tint of a near-black grey, so it is invisible against the dark background it is meant to dim.

### fix: land focus on LogosTextField's editor

Handing the field focus (a dialog's opening forceActiveFocus, tab, key navigation) stopped at the wrapper control: the caret never appeared and keystrokes went nowhere. The control now accepts StrongFocus and forwards active focus to its editor.

---

The button sizing moves every consumer's layout, so this wants a look in the storybook before it merges. Verified locally with the pinned Qt 6.9.2: the QML suite passes at each commit (309, 315, 316, 317).

Based just below the static qt_add_qml_module refactor on purpose: the module-builder standalone app cannot load the static design system yet, and logos-chat-ui pins this branch to run the app with these fixes. Rebasing onto current master is mechanical once the module builder consumes the static modules.
