### PR TITLE
feat: give LogosButton a distinct pressed state

### DIFF
--- a/src/qml/Logos/Controls/LogosButton.qml
+++ b/src/qml/Logos/Controls/LogosButton.qml
@@ -9,8 +9,9 @@ import Logos.Controls
 // A Control that pairs a centered text label with an optional LogosIcon on
 // either side of it. The implicit size follows the content, so a button left
 // at its natural size fits its own label; a label constrained by an explicit
-// width is elided rather than overflowing the button. Colors, border and
-// cursor react to hover/press and enabled state.
+// width is elided rather than overflowing the button. Colors and border react
+// to hover, press, and enabled state (pressed takes priority over hovered).
+// Cursor reflects enabled state.
 //
 // Public API:
 //     text         button label. Drives the implicit width. Elided with "…"
@@ -22,6 +23,7 @@ import Logos.Controls
 //     variant      LogosButton.Variant.Primary or .Secondary (default). Drives
 //                  the background and border palette.
 //     radius       background corner radius. Default = Theme.spacing.radiusXlarge.
+//     pressed      read-only; true while the mouse is held down on the button.
 //     clicked      signal emitted when an enabled button is clicked.
 //
 // IconSpec fields:
@@ -37,6 +39,7 @@ import Logos.Controls
 //     labelItem         the text label
 //     leadingIconItem   the LogosIcon before the label
 //     trailingIconItem  the LogosIcon after the label
+//     _backgroundColor  d.backgroundColor; not for app use
 //
 // Example:
 //     LogosButton {
@@ -65,7 +68,8 @@ Control {
     property real radius: Theme.spacing.radiusXlarge
     property int variant: LogosButton.Variant.Secondary
 
-    readonly property bool isActive: mouseArea.pressed || root.hovered
+    readonly property bool pressed: mouseArea.containsPress
+    readonly property bool isActive: root.pressed || root.hovered
 
     signal clicked()
 
@@ -75,6 +79,28 @@ Control {
     readonly property alias labelItem: label
     readonly property alias leadingIconItem: iconLeft
     readonly property alias trailingIconItem: iconRight
+    readonly property var _backgroundColor: d.backgroundColor
+
+    QtObject {
+        id: d
+
+        function backgroundColor(enabled, variant, pressed, hovered) {
+            if (!enabled)
+                return Theme.palette.backgroundMuted
+            if (variant === LogosButton.Variant.Primary) {
+                if (pressed)
+                    return Theme.palette.primaryPressed
+                if (hovered)
+                    return Theme.palette.primaryHover
+                return Theme.palette.primary
+            }
+            if (pressed)
+                return Theme.palette.background
+            if (hovered)
+                return Theme.palette.backgroundMuted
+            return Theme.palette.backgroundSecondary
+        }
+    }
 
     // Floors keep short labels ("OK") on a balanced pill, and hold the height
     // steady whether or not the button carries a default-sized (20px) icon;
@@ -92,13 +118,7 @@ Control {
 
     background: Rectangle {
         id: bg
-        color: {
-            if (!root.enabled)
-                return Theme.palette.backgroundMuted
-            if (root.variant === LogosButton.Variant.Primary)
-                return root.isActive ? Theme.palette.primaryHover : Theme.palette.primary
-            return root.isActive ? Theme.palette.backgroundMuted : Theme.palette.backgroundSecondary
-        }
+        color: d.backgroundColor(root.enabled, root.variant, root.pressed, root.hovered)
         radius: root.radius
         border.width: 1
         border.color: {
@@ -151,6 +171,7 @@ Control {
         id: mouseArea
         anchors.fill: parent
         enabled: root.enabled
+        hoverEnabled: true
         cursorShape: root.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         onClicked: root.clicked()
     }

--- a/src/qml/Logos/Theme/ColorPalette.qml
+++ b/src/qml/Logos/Theme/ColorPalette.qml
@@ -52,6 +52,7 @@ QtObject {
     readonly property color orange500: "#F55702"
     readonly property color orange600: "#F57A02"
     readonly property color orange700: "#BF5104"
+    readonly property color orange800: "#8F3C03"
 
     // Peach shades (Soft accents)
     readonly property color peach100: "#FFD5C0"

--- a/src/qml/Logos/Theme/DarkTheme.qml
+++ b/src/qml/Logos/Theme/DarkTheme.qml
@@ -35,7 +35,7 @@ QtObject {
 
     readonly property color primary: colors.orange300
     readonly property color primaryHover: colors.orange500
-    readonly property color primaryPressed: colors.orange600
+    readonly property color primaryPressed: colors.orange800
     readonly property color primarySoft: colors.peach100
 
     readonly property color success: colors.green500

--- a/storybook/pages/LogosButtonPage.qml
+++ b/storybook/pages/LogosButtonPage.qml
@@ -28,7 +28,7 @@ Rectangle {
                 color: Theme.palette.text
             }
             LogosText {
-                text: "Public API: text, variant, icon, enabled, clicked()"
+                text: "Public API: text, variant, icon, radius, enabled, pressed, clicked()"
                 font.pixelSize: Theme.typography.secondaryText
                 color: Theme.palette.textSecondary
             }

--- a/tests/tst_LogosButton.qml
+++ b/tests/tst_LogosButton.qml
@@ -89,6 +89,27 @@ TestCase {
         tryCompare(btn.backgroundItem, "color", Theme.palette.primary)
     }
 
+    function test_primary_pressed_uses_primary_pressed_fill() {
+        const primary = LogosButton.Variant.Primary
+        compare(btn._backgroundColor(true, primary, false, false), Theme.palette.primary)
+        compare(btn._backgroundColor(true, primary, false, true), Theme.palette.primaryHover)
+        compare(btn._backgroundColor(true, primary, true, true), Theme.palette.primaryPressed)
+        compare(btn._backgroundColor(true, primary, true, false), Theme.palette.primaryPressed)
+
+        btn.variant = LogosButton.Variant.Primary
+        tryCompare(btn.backgroundItem, "color", Theme.palette.primary)
+    }
+
+    function test_secondary_pressed_uses_background_fill() {
+        const secondary = LogosButton.Variant.Secondary
+        compare(btn._backgroundColor(true, secondary, false, false), Theme.palette.backgroundSecondary)
+        compare(btn._backgroundColor(true, secondary, false, true), Theme.palette.backgroundMuted)
+        compare(btn._backgroundColor(true, secondary, true, true), Theme.palette.background)
+        compare(btn._backgroundColor(true, secondary, true, false), Theme.palette.background)
+
+        tryCompare(btn.backgroundItem, "color", Theme.palette.backgroundSecondary)
+    }
+
     function test_disabled_wins_over_primary() {
         btn.variant = LogosButton.Variant.Primary
         btn.leadingIcon.source = "qrc:/test-icon.png"


### PR DESCRIPTION
fixes  #42

Hover and press previously shared one fill; pressed now uses its own colors so Primary/Secondary buttons give clearer click feedback.



https://github.com/user-attachments/assets/3c43c8fa-9ace-4022-a9b4-07856e73cb1e

