### PR TITLE
test: steady the control-test assertions and cover AlwaysOff

### DIFF
--- a/tests/tst_LogosButton.qml
+++ b/tests/tst_LogosButton.qml
@@ -142,7 +142,7 @@ TestCase {
 
     function test_default_width_fits_the_label() {
         btn.text = "This is a very long label that will not fit inside 100px"
-        tryVerify(function() { return !btn.labelItem.truncated })
+        tryCompare(btn.labelItem, "truncated", false)
         verify(btn.width >= btn.labelItem.implicitWidth + btn.leftPadding + btn.rightPadding)
     }
 
@@ -152,13 +152,13 @@ TestCase {
     }
 
     function test_icon_adds_a_single_slot_to_the_width() {
-        tryVerify(function() { return !iconSizing.labelItem.truncated })
+        tryCompare(iconSizing.labelItem, "truncated", false)
         compare(iconSizing.implicitWidth,
                 plainSizing.implicitWidth + iconSizing.leadingIcon.size + iconSizing.contentItem.spacing)
     }
 
     function test_both_icons_add_two_slots_to_the_width() {
-        tryVerify(function() { return !bothIconsSizing.labelItem.truncated })
+        tryCompare(bothIconsSizing.labelItem, "truncated", false)
         compare(bothIconsSizing.implicitWidth,
                 iconSizing.implicitWidth + bothIconsSizing.trailingIcon.size + bothIconsSizing.contentItem.spacing)
     }

--- a/tests/tst_LogosScrollBar.qml
+++ b/tests/tst_LogosScrollBar.qml
@@ -45,20 +45,22 @@ TestCase {
         tryCompare(bar.barItem, "implicitWidth", 10)
     }
 
+    // size comes from the Flickable's visibleArea, which settles a frame after
+    // the scene is shown, so every size assertion below polls for it.
     function test_hidden_when_content_fits() {
-        compare(fittingBar.size, 1)
+        tryCompare(fittingBar, "size", 1)
         tryCompare(fittingBar.barItem, "opacity", 0)
     }
 
     // The overlay bar stays hidden at rest even when the content overflows: it
     // is not tied to ScrollBar.active, which the runtime can leave stuck on.
     function test_hidden_at_rest_when_content_overflows() {
-        verify(bar.size < 1)
+        tryVerify(function() { return bar.size < 1 })
         tryCompare(bar.barItem, "opacity", 0)
     }
 
     function test_shown_after_a_scroll() {
-        verify(bar.size < 1)
+        tryVerify(function() { return bar.size < 1 })
         bar.position = 0.3
         tryCompare(bar.barItem, "opacity", 1)
     }

--- a/tests/tst_LogosScrollBar.qml
+++ b/tests/tst_LogosScrollBar.qml
@@ -69,4 +69,11 @@ TestCase {
         bar.policy = ScrollBar.AlwaysOn
         tryCompare(bar.barItem, "opacity", 1)
     }
+
+    // AlwaysOff is honoured by the style's own `visible` binding rather than by
+    // the handle's opacity, so nothing here may override visible.
+    function test_always_off_hides_the_bar() {
+        bar.policy = ScrollBar.AlwaysOff
+        tryCompare(bar, "visible", false)
+    }
 }


### PR DESCRIPTION
Follow-ups from the review on #39, none of which change a control.

### test: poll for the scroll bar's size instead of reading it straight

`size` is derived from the Flickable's `visibleArea`, which settles a frame after the scene is shown. Three assertions read it with `compare`/`verify`, so they assert on whatever value the first frame happens to carry.

### test: cover that AlwaysOff keeps the scroll bar off screen

The handle's opacity expression deliberately says nothing about `ScrollBar.AlwaysOff`, which looks like a gap: hover or a recent scroll step would seem to reveal a bar the policy switched off. It cannot. Every style, including the Basic one both `tests/main.cpp` and `storybook/main.cpp` select, binds `visible: policy !== ScrollBar.AlwaysOff` on the control itself, and `LogosScrollBar` never overrides `visible`, so an AlwaysOff bar is neither rendered nor hoverable. The new test pins that inherited binding rather than duplicating the check as dead logic in the opacity expression.

### test: wait on the label's truncated property directly

Three sizing tests polled a closure for a plain property read, which `tryCompare` already does.

---

319 tests pass on the pinned Qt 6.9.2, at each commit.