### PR TITLE
feat(windows): cross-build the design system and its storybook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,15 @@
   "nodes": {
     "logos-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-windows": "nixpkgs-windows"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -54,11 +55,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782913618,
-        "narHash": "sha256-WzkZzJ3VSotFMOjbEDfjHZP0KoBW6GVi1Xc9i1E6mMY=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4f72d7a64dd83979d771c17161f23ebc9dbedb40",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -106,6 +107,22 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -31,18 +31,25 @@
 
   outputs = { self, logos-nix, nixpkgs, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app }:
     let
-      systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
-        inherit system;
-        pkgs = import nixpkgs { inherit system; };
-      });
+      # nix-bundle-dir RUNS on the builder, so on a cross target it comes from
+      # the build system. It is also ELF/Mach-O only (its bundle.sh branches
+      # `file -b` -> Mach-O | ELF with no PE case), so a Windows bundle must not
+      # be produced through it -- see the guard on `storybook-bundle` below.
+      buildSystemFor = target:
+        if target == "x86_64-windows" then "x86_64-linux" else target;
+
+      # Adds the "x86_64-windows" pseudo-system. A cross derivation's `system`
+      # attr is its BUILD platform, so these evaluate anywhere and realise on
+      # x86_64-linux.
+      forAllSystems = f: logos-nix.lib.forAllTargets ({ system, pkgs }:
+        f { inherit system pkgs; });
     in
     {
       packages = forAllSystems ({ pkgs, system, ... }:
         let
           common = import ./nix/common.nix { inherit pkgs; };
           storybookDrv = import ./nix/storybook.nix { inherit pkgs common; };
-          dirBundler = nix-bundle-dir.bundlers.${system}.qtApp;
+          dirBundler = nix-bundle-dir.bundlers.${buildSystemFor system}.qtApp;
         in
         rec {
           default = import ./nix/library.nix { inherit pkgs common; };

--- a/nix/common.nix
+++ b/nix/common.nix
@@ -14,8 +14,14 @@
   nativeBuildInputs = [
     pkgs.cmake
     pkgs.ninja
-    pkgs.qt6.wrapQtAppsHook
-  ];
+  ]
+  # wrapQtAppsHook FAILS TO EVALUATE for a mingw host, and would be useless
+  # anyway: wrap-qt-apps-hook.sh does `isELF || isMachO || continue`, so a PE is
+  # never wrapped. Gating it off is only half the fix -- qtbase's own setup hook
+  # hard-errors in qtPreHook with "depends on qtbase, but no wrapping behavior
+  # was specified" unless `dontWrapQtApps = true` is also set on each
+  # derivation. Both halves are mandatory.
+  ++ pkgs.lib.optional (!pkgs.stdenv.hostPlatform.isWindows) pkgs.qt6.wrapQtAppsHook;
 
   buildInputs = [
     pkgs.qt6.qtbase
@@ -29,5 +35,12 @@
   baseCmakeFlags = [
     "-GNinja"
     "-DCMAKE_BUILD_TYPE=Release"
-  ];
+  ]
+  # Qt splits its host TOOLS (moc, rcc, qmltyperegistrar, qsb) into separate
+  # packages that must run on the BUILD machine; -DQT_HOST_PATH=<qtbase> cannot
+  # reach them. The overlay hoists the required Qt6*Tools_DIR flags into this
+  # attribute, which is empty on native builds. The symptom when it is missing
+  # is misleading -- CMake names the target-side package (e.g. Qt6QmlTools),
+  # which is present; it is the host-tools package that is absent.
+  ++ (pkgs.logosQtCrossCmakeFlags or [ ]);
 }

--- a/nix/library.nix
+++ b/nix/library.nix
@@ -14,6 +14,9 @@ pkgs.stdenv.mkDerivation rec {
 
   cmakeFlags = common.baseCmakeFlags;
 
+  # Required wherever the Qt wrapper hooks are absent (see nix/common.nix).
+  dontWrapQtApps = true;
+
   # Standard configure/build/install — supersedes the previous "just cp -r
   # the source tree into $out/lib/Logos" install path.
   configurePhase = ''
@@ -36,6 +39,6 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Logos Design System - Qt/QML themes, colors, typography";
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }

--- a/nix/storybook.nix
+++ b/nix/storybook.nix
@@ -13,6 +13,9 @@ pkgs.stdenv.mkDerivation rec {
     "-DLOGOS_DS_BUILD_STORYBOOK=ON"
   ];
 
+  # Required wherever the Qt wrapper hooks are absent (see nix/common.nix).
+  dontWrapQtApps = true;
+
   configurePhase = ''
     runHook preConfigure
     cmake -S . -B build $cmakeFlags
@@ -29,7 +32,26 @@ pkgs.stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp build/storybook/LogosStorybook $out/bin/
+    # Probe both names and FAIL if neither is there. Naming only the unsuffixed
+    # binary meant a mingw build -- which links LogosStorybook.exe -- died with
+    # "cp: cannot stat 'build/storybook/LogosStorybook'" immediately after the
+    # link step had succeeded.
+    # Search the tree rather than hardcoding a directory: on Windows CMake puts
+    # RUNTIME artifacts in the runtime output directory (the build root here) so
+    # that executables and their DLLs end up side by side, while the ARCHIVE
+    # artifact -- libLogosStorybook.dll.a -- stays in build/storybook/. Looking
+    # only in build/storybook/ finds the import library and no binary.
+    _sb=""
+    for _cand in $(find build -maxdepth 3 -type f \
+                     \( -name LogosStorybook -o -name LogosStorybook.exe \) 2>/dev/null); do
+      _sb="$_cand"; break
+    done
+    if [ -z "$_sb" ]; then
+      echo "Error: the LogosStorybook binary was not produced by the build" >&2
+      ls -la build/storybook 2>&1 >&2 || echo "  (no build/storybook directory)" >&2
+      exit 1
+    fi
+    cp "$_sb" $out/bin/
 
     # Storybook pages: installed under lib/ so nix-bundle-dir carries them
     # through. It closure-walks share/ (drops anything the binary doesn't
@@ -52,6 +74,6 @@ pkgs.stdenv.mkDerivation rec {
   meta = with pkgs.lib; {
     description = "Browse and preview Logos Design System components";
     mainProgram = "LogosStorybook";
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }


### PR DESCRIPTION
Windows cross target for the design system. **L3 of the Windows chain**, re-pinned to the merged `logos-nix` and `nix-bundle-dir`.

Milestone 0 of the Basecamp port: the first Qt **Quick** application to cross-compile for Windows. `LogosStorybook.exe` now builds with `Qt6Quick.dll` staged beside it, which is also the end-to-end confirmation of the logos-nix change that made `qtdeclarative` actually build Qt Quick.

## The flake

`packages` routes through `logos-nix.lib.forAllTargets`, and `meta.platforms` is widened. `nix-bundle-dir` is keyed by **buildSystem** rather than host: it runs on the builder and is ELF/Mach-O only, so a Windows bundle must not be produced through it at all. `baseCmakeFlags` picks up `pkgs.logosQtCrossCmakeFlags` for Qt's host-tool packages, which is empty natively.

`wrapQtAppsHook` is **gated rather than removed**. It does not evaluate for a mingw host and would be useless anyway — `wrap-qt-apps-hook.sh` does `isELF || isMachO || continue` — but dropping it outright would change native behaviour. `dontWrapQtApps = true` is the mandatory other half, or qtbase's own hook hard-errors in `qtPreHook`.

## Where a reviewer should look

The install probe **searches** the build tree instead of naming a directory. On Windows CMake puts RUNTIME artifacts in the runtime output directory — the build root — so executables sit beside their DLLs, while the ARCHIVE artifact (`libLogosStorybook.dll.a`) stays in `build/storybook/`. Probing `build/storybook/` alone finds the import library and no binary, which is how this first failed. It now fails loudly with a directory listing rather than a bare `cp: cannot stat`.

The branch is based on `origin/master`, which the previous submodule pointer trailed by 30 commits. The static-QML `library.nix` visible here is that upstream work, not part of this change.
